### PR TITLE
Add APT config to base image

### DIFF
--- a/Tekst-API/Dockerfile
+++ b/Tekst-API/Dockerfile
@@ -5,6 +5,13 @@
 
 FROM python:3.10-slim-bullseye AS base
 
+COPY --chmod=0644 <<"EOF" /etc/apt/apt.conf
+APT::Get::Assume-Yes "true";
+APT::Install-Recommends "0";
+APT::Install-Suggests "0";
+APT::Sandbox::User "root";
+EOF
+
 ENV PYTHONFAULTHANDLER=1 \
     PYTHONHASHSEED=random \
     PYTHONUNBUFFERED=1 \
@@ -69,8 +76,7 @@ ENV FASTAPI_ENV=production
 
 # install needed OS packages
 RUN apt-get update && \
-    apt-get install --no-install-recommends -y \
-        curl && \
+    apt-get install curl && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
This pull request introduces a minor alteration to the Dockerfile build stages: By creating an `/etc/apt/apt.conf`iguration file with appropriate values within the `base` build stage, all subsequent stages will inherit this configuration and no further arguments to individual invokations of `apt-get` have to be supplied.

The created `/etc/apt/apt.conf`iguration replaces the following arguments to `apt-get` globally:
```sh
apt-get -y --yes                   # APT::Get::Assume-Yes "true";
apt-get --no-install-recommends    # APT::Install-Recommends "0";
apt-get --no-install-suggests      # APT::Install-Suggests "0";
apt-get -o APT::Sandbox::User=root # APT::Sandbox::User "root";
```