### PR TITLE
Refine docker deployment

### DIFF
--- a/docker/caddy/Caddyfile
+++ b/docker/caddy/Caddyfile
@@ -11,29 +11,33 @@
 		max_size {$TEKST_MAX_REQ_SIZE:250MB}
 	}
 
+	# redirect root requests to use trailing slash
+	@root expression {path} == "{$TEKST_WEB_PATH}"
+	redir @root {$TEKST_WEB_PATH}/
+
 	# redirect API requests to use trailing slash
-	redir /api /api/
+	redir {$TEKST_WEB_PATH}/api {$TEKST_WEB_PATH}/api/
 
 	# proxy all API requests to API app
-	handle_path /api/* {
+	handle_path {$TEKST_WEB_PATH}/api/* {
 		reverse_proxy http://127.0.0.1:8000
 	}
 
 	# serve static files (custom assets)
-	handle_path /static/* {
+	handle_path {$TEKST_WEB_PATH}/static/* {
 		root * /var/www/tekst/static
 		file_server
 	}
 
 	# help browsers to find the custom favicon at root
 	# (ofc this only works if the app is served at root path "/")
-	handle_path /favicon.ico {
-		root * /var/www/tekst/static
+	handle_path {$TEKST_WEB_PATH}/favicon.ico {
+		root /var/www/tekst/static/favicon.ico
 		file_server
 	}
 
 	# serve web client files
-	handle_path /* {
+	handle_path {$TEKST_WEB_PATH}/* {
 		root * /var/www/html
 		try_files {path} /index.html
 		file_server

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,21 +1,21 @@
-#!/bin/sh
+#!/bin/sh -e
 
 # run DB migration if arg #1 is "migrate"
-if [ "$1" = "migrate" ]; then
+if [[ "$1" == "migrate" ]]; then
     python3 -m tekst migrate
     exit $?
-fi;
+fi
 
 # run bootstrapping routine first
 python3 -m tekst bootstrap
-test $? -ne 0 && exit 1
 
 # remove (all) trailing slashes from TEKST_WEB_PATH
 TEKST_WEB_PATH=$(echo "$TEKST_WEB_PATH" | sed 's|/*$||')
+
 # remove existing base tag from client's index.html, if any
-sed -i 's|<base href=".*">||g' /var/www/html/index.html
-# inject base tag with base URL into client's index.html
-sed -i 's|<head>|<head><base href="'"$TEKST_WEB_PATH"'/" />|g' /var/www/html/index.html
+# and inject base tag with base URL into client's index.html
+sed -Ei /var/www/html/index.html -e 's|<base [^>]+>||' \
+    -e 's|<head>|\0<base href="'"$TEKST_WEB_PATH/"'" />|'
 
 # start caddy (will detach and run in background after startup)
 caddy start --config /etc/caddy/Caddyfile


### PR DESCRIPTION
This pull request refines the docker deployment by changing the `entrypoint.sh` and `Caddyfile` used within Tekst the container. The changes to the `entrypoint.sh` are mostly opinionated shell script refinements (e.g., use `-e` in the shebang to enable `errexit`, chain `sed` commands etc.), while the changes to the `Caddyfile` implement the possibility to deploy Tekst within context-paths (e.g. `https://my-tekst.app/tekst-context-path/`) by introducing the `TEKST_WEB_PATH` environment variable as a prefix to all Caddy handlers.