### PR TITLE
Make it visually clear that the "show all" buttons next to resource category headings in browse view are buttons and not links

### DIFF
--- a/Tekst-Web/src/views/BrowseView.vue
+++ b/Tekst-Web/src/views/BrowseView.vue
@@ -122,7 +122,7 @@ onMounted(() => {
           !browse.focusView &&
           !!category.category.translation
         "
-        align="baseline"
+        align="center"
         class="mb-md"
       >
         <h2
@@ -136,7 +136,7 @@ onMounted(() => {
         </h2>
         <n-button
           v-if="!!catHiddenResCount[category.category.key || '']"
-          text
+          secondary
           :focusable="false"
           size="tiny"
           class="translucent"


### PR DESCRIPTION
Fixes #1421